### PR TITLE
デフォルト挙動と保存処理の改善（v0.1.6）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,12 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 upload.sh
+
+# macOS固有ファイル
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# たまにできるSpotlight系
+.Spotlight-V100
+.Trashes

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mdtree --path ./your_project --max-depth 2 --ignore-list ./mypy_cache --ignore-l
 例えばこのリポジトリのルートで以下のように実行すると・・・
 
 ``` bash
-mdtree --ignore-list .DS_Store --savepath 好きなパス.md
+mdtree --savepath 好きなパス.md
 ```
 
 こんな感じのコードブロックを持ったmdファイル`好きなパス.md`が生成されます。
@@ -81,6 +81,7 @@ mdtree
 |    |    ├── test_cli.py
 |    |    └── test_structure.py
 |    └── treebuilder.py
+├── mdtree_output.md
 ├── pyproject.toml
 └── requirements.txt
 ```
@@ -154,7 +155,7 @@ mdtree --path ./your_project --max-depth 2 --ignore-list .mypy_cache --ignore-li
 For example, running the following command at the root of this repository:
 
 ```bash
-mdtree --ignore-list .DS_Store --savepath path-you-like.md
+mdtree --savepath path-you-like.md
 ```
 
 Generates a Markdown file `path-you-like.md` containing a code block like this, and also copies the block to your clipboard:
@@ -171,6 +172,7 @@ mdtree
 |    |    ├── test_cli.py
 |    |    └── test_structure.py
 |    └── treebuilder.py
+├── mdtree_output.md
 ├── pyproject.toml
 └── requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mdtree --path ./your_project --max-depth 2 --ignore-list ./mypy_cache --ignore-l
 - `--apply-gitignore / --no-apply-gitignore` : `.gitignore`設定に基づく除外を適用/適用しない（default: 適用する）
 - `--exclude-git / --no-exclude-git` : `.git`ディレクトリを除外する/しない（default: 除外する）
 - `--clipboard / --no-clipboard` : 出力をクリップボードにコピーする/しない（default: コピーする）
-- `--savepath [FILE]` : Markdownファイルに書き出すパスを指定（default: `tree.md`）
+- `--savepath [FILE]` : Markdownファイルに書き出すパスを指定（encoding: utf-8, default: `None` 保存しない）
 - `--help` : 使い方ヘルプを表示
 
 ---
@@ -135,7 +135,7 @@ mdtree --path ./your_project --max-depth 2 --ignore-list .mypy_cache --ignore-li
 - `--apply-gitignore / --no-apply-gitignore` : Apply or ignore `.gitignore` settings (default: apply)
 - `--exclude-git / --no-exclude-git` : Exclude or include the `.git` directory (default: exclude)
 - `--clipboard / --no-clipboard` : Copy output to clipboard or not (default: copy)
-- `--savepath [FILE]` : Path to save output as a Markdown file (default: `tree.md`)
+- `--savepath [FILE]` : Path to save output as a Markdown file (encoding: utf-8, default: `None`)
 - `--help` : Display help
 
 ---

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ mdtree --path ./your_project --max-depth 2 --ignore-list ./mypy_cache --ignore-l
 例えばこのリポジトリのルートで以下のように実行すると・・・
 
 ``` bash
-mdtree --ignore-list .DS_Store
+mdtree --ignore-list .DS_Store --savepath 好きなパス.md
 ```
 
-こんな感じのコードブロックを持ったmdファイルが`mdtree/tree.md`に生成されます。
+こんな感じのコードブロックを持ったmdファイル`好きなパス.md`が生成されます。
 また、コードブロック内のテキストがクリップボードに追加されます。
 
 ``` plaintext
@@ -154,10 +154,10 @@ mdtree --path ./your_project --max-depth 2 --ignore-list .mypy_cache --ignore-li
 For example, running the following command at the root of this repository:
 
 ```bash
-mdtree --ignore-list .DS_Store
+mdtree --ignore-list .DS_Store --savepath path-you-like.md
 ```
 
-Generates a Markdown file `mdtree/tree.md` containing a code block like this, and also copies the block to your clipboard:
+Generates a Markdown file `path-you-like.md` containing a code block like this, and also copies the block to your clipboard:
 
 ```plaintext
 mdtree

--- a/mdtree/__main__.py
+++ b/mdtree/__main__.py
@@ -39,7 +39,7 @@ from mdtree.treebuilder import build_structure_tree, validate_and_convert_path
 @click.option(
     "--savepath",
     type=click.Path(exists=False, dir_okay=False),
-    default="tree.md",
+    default=None,
     help="textで書き出し",
 )
 def main(
@@ -67,7 +67,7 @@ def main(
         sp.parent.mkdir(exist_ok=True, parents=True)
         sp.touch()
         text = "# structure_tree\n\n" + "``` plaintext\n" + res + "\n```\n"
-        sp.write_text(text)
+        sp.write_text(text, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/mdtree_output.md
+++ b/mdtree_output.md
@@ -13,5 +13,6 @@ mdtree
 |    |    └── test_structure.py
 |    └── treebuilder.py
 ├── pyproject.toml
-└── requirements.txt
+├── requirements.txt
+└── test.md
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mdtree_py"
-version = "0.1.5"
+version = "0.1.6"
 description = "Output directory structure as Markdown code block"
 authors = [{ name = "a-duty-rookie" }]
 readme = "README.md"


### PR DESCRIPTION
## 概要

CLIツール mdtree の使い勝手と信頼性向上のため、以下のような改善を加えました。
それに伴い、バージョンを 0.1.6 にアップデートしています。

⸻

## 🔧 変更内容
- --savepath オプションのデフォルトを mdtree.md → None に変更 
→ デフォルトではファイル出力せず、明示的な指定があった場合のみ保存
- Path.write_text(..., encoding="utf-8") による出力時のエンコーディング明示化
- README.md に変更点を反映（CLIオプションの説明など）
- pyproject.toml の version を 0.1.6 に更新

⸻

## 🎯 動機・背景
- ファイル保存のデフォルト挙動を抑制することで、誤って不要なファイルが生成されるのを防ぎたかった
- 出力ファイルのエンコーディングを明示することで、特にWindows環境などでの文字化けリスクを低減
- 利用者にとってわかりやすいCLI挙動・ヘルプを整えるためにREADMEも合わせて修正

⸻

## 📝 補足
- 今回の修正により、--clipboard はこれまで通り既定で有効です
- --savepath を指定すれば、これまで通りMarkdown形式で書き出されます（utf-8で保存されます）